### PR TITLE
Add units support and other improvements

### DIFF
--- a/report/analysis.py
+++ b/report/analysis.py
@@ -328,13 +328,50 @@ class Report:
         >>> report = rp.report_example()
         >>> fig = report._plot_ucs()
         """
+        max_speed = self.config.rotor_properties.rotor_speeds.max_speed
+        min_speed = self.config.rotor_properties.rotor_speeds.min_speed
+        oper_speed = self.config.rotor_properties.rotor_speeds.oper_speed
+        trip_speed = self.config.rotor_properties.rotor_speeds.trip_speed
+        units = self.config.rotor_properties.rotor_speeds.unit
+        frequency_units = self.config.plot_ucs.frequency_units
+
         fig = self.rotor.plot_ucs(
             stiffness_range=self.config.plot_ucs.stiffness_range,
             num_modes=self.config.plot_ucs.num_modes,
             num=self.config.plot_ucs.num,
             synchronous=self.config.plot_ucs.synchronous,
             stiffness_units=self.config.plot_ucs.stiffness_units,
-            frequency_units=self.config.plot_ucs.frequency_units,
+            frequency_units=frequency_units
+        )
+
+        _speeds = [min_speed, max_speed, oper_speed, trip_speed]
+        speeds = [Q_(speed, units).to(frequency_units).m for speed in _speeds]
+        labels = ["min. speed", "max. speed", "rated speed", "trip speed"]
+
+        for speed, label in zip(speeds, labels):
+            fig.add_trace(
+                go.Scatter(
+                    x=[min(fig.data[0].x), max(fig.data[0].x)],
+                    y=[speed, speed],
+                    mode="lines",
+                    line=dict(color="black", dash="dot", width=2),
+                    name=label,
+                    hoverinfo="none",
+                    showlegend=False,
+                    yaxis="y2",
+                )
+            )
+
+        fig.update_layout(
+            yaxis2=dict(
+                ticktext=labels,
+                tickvals=speeds,
+                type="log",
+                matches="y",
+                anchor="x",
+                overlaying="y",
+                side="right",
+            ),
         )
 
         return fig

--- a/report/config.py
+++ b/report/config.py
@@ -313,6 +313,15 @@ class Config:
         unit: str, optional
             Unit system. Options are "m" (meter) and "in" (inch).
             Default is "m".
+        length_unit : str
+            Length units for D and H arguments.
+            Default is "m".
+        power_unit : str
+            Power unit for rated_power argument.
+            Default is "hp".
+        density_unit : str
+            Density unit for rho_suction and rho_discharge arguments.
+            Default is "kg/m**3".
 
     Returns
     -------
@@ -408,7 +417,9 @@ class Config:
             "rho_ratio": None,
             "rho_suction": None,
             "rho_discharge": None,
-            "unit": "m",
+            "length_unit": "m",
+            "power_unit": "hp",
+            "density_unit": "kg/m**3",
         })
         # fmt: on
 

--- a/report/config.py
+++ b/report/config.py
@@ -296,10 +296,13 @@ class Config:
         plot_deflected_shape : dict
             Options to configurate the deflected shape plot.
 
-            speed : list, array,
+            speed : list, array
                 List with selected speed to plot the deflected shape.
                 The speed values must be elements from frequency_range option,
                 otherwise it returns an error.
+            speed_units : str, optional
+                Units for selected speed in deflected shape analisys.
+                Default is "rad/s".
 
     stability_level1 : dict
         Dictionary configurating stability_level_1 parameters.
@@ -421,6 +424,7 @@ class Config:
             "rotor_length_units": "m",
             "plot_deflected_shape": {
                 "speed": [],
+                "speed_units": "rad/s",
             },
         })
 

--- a/report/config.py
+++ b/report/config.py
@@ -288,7 +288,18 @@ class Config:
             Default is "m/N"
         phase_units : str, optional
             Phase units.
-            Default is "rad"
+            Default is "rad".
+        rotor_length_units : str, optional
+            Units for rotor length.
+            Default is "m".
+
+        plot_deflected_shape : dict
+            Options to configurate the deflected shape plot.
+
+            speed : list, array,
+                List with selected speed to plot the deflected shape.
+                The speed values must be elements from frequency_range option,
+                otherwise it returns an error.
 
     stability_level1 : dict
         Dictionary configurating stability_level_1 parameters.
@@ -407,6 +418,10 @@ class Config:
             "frequency_units": "rad/s",
             "amplitude_units": "m",
             "phase_units": "rad",
+            "rotor_length_units": "m",
+            "plot_deflected_shape": {
+                "speed": [],
+            },
         })
 
         # Configurating stability level 1 analysis


### PR DESCRIPTION
- Add units support with Pint

- Split `_mode_shape()` method into 2. 
    - `_mode_shape()` calculates the nodes that will receive the unbalances
    - `_plot_mode_shape()`  returns the figure

- Add probe system to unbalance_response
    - It Has the same logic of `node` and `orientation` than ROSS

- `run_report()` group results by bearings setup (minimum, maximum and operation clearances). The global dictionary is similar in organization to `Config()` class. 
- Add logic to run stability analysis if the parameter `condition` is True (defined by stability level 1.