### PR TITLE
Verifying disks inertias

### DIFF
--- a/report/analysis.py
+++ b/report/analysis.py
@@ -1238,7 +1238,7 @@ class Report:
             else:
                 condition = False
 
-        if machine_type == "turbine" or machine_type == "axial flow":
+        if machine_type == "turbine" or machine_type == "axial_flow":
             if log_dec_a < 0.1:
                 condition = True
 


### PR DESCRIPTION
Disks with inertia equal to 0 would be a problem for the code interpretation. It could misslead the rotor type and guide the analyses through a completely different way it should.
Adding a inertia verification at the beginning will cut off all disks with 0 inertia (mass only) for the rotor type consideration. Notice that it does not remove these disks from the model. They just won't be considered to the rotor type definition (if between bearings, overhung, etc).