### PR TITLE
Improving Report units system

### DIFF
--- a/report/analysis.py
+++ b/report/analysis.py
@@ -676,9 +676,8 @@ class Report:
         minspeed = self.config.rotor_properties.rotor_speeds.min_speed
         speed_factor = self.config.rotor_properties.rotor_speeds.speed_factor
         speed_unit = self.config.rotor_properties.rotor_speeds.unit
-        plot_speeds = self.config.run_unbalance_response.plot_deflected_shape.speed
-        spd_unit = self.config.run_unbalance_response.plot_deflected_shape.speed_units
 
+        plot_speeds = self.config.run_unbalance_response.plot_deflected_shape.speed
         freq_range = self.config.run_unbalance_response.frequency_range
         modes = self.config.run_unbalance_response.modes
         cluster_points = self.config.run_unbalance_response.cluster_points
@@ -691,13 +690,13 @@ class Report:
         phase_units = self.config.run_unbalance_response.phase_units
         rotor_length_units = self.config.run_unbalance_response.rotor_length_units
 
-        maxspeed = Q_(maxspeed, speed_unit).to(frequency_units).m
-        minspeed = Q_(minspeed, speed_unit).to(frequency_units).m
-
         if freq_range is None and not cluster_points:
             freq_range = np.linspace(
                 0, speed_factor * Q_(maxspeed, speed_unit).to("rad/s").m, 201
             )
+
+        maxspeed = Q_(maxspeed, speed_unit).to("rad/s").m
+        minspeed = Q_(minspeed, speed_unit).to("rad/s").m
 
         # returns de nodes where forces will be applied
         node_max, node_min = self._mode_shape(mode)
@@ -788,7 +787,7 @@ class Report:
                     SM_ref = "None"
 
                 # amplitude limit (A1) - API684 - SP6.8.2.11
-                A1 = 25.4 * np.sqrt(12000 / Q_(maxspeed, speed_unit).to("rpm")) * 1e-6
+                A1 = 25.4 * np.sqrt(12000 / Q_(maxspeed, "rad/s").to("rpm")) * 1e-6
                 A1 = Q_(A1, "m").to(amplitude_units).m
                 Amax = max(data.y)
 
@@ -805,6 +804,8 @@ class Report:
             unbalance_dict["probe {}".format(k + 1)] = _dict
             k += 1
 
+        maxspeed = Q_(maxspeed, "rad/s").to(frequency_units).m
+        minspeed = Q_(minspeed, "rad/s").to(frequency_units).m
         customdata = [minspeed, maxspeed]
         max_amplitude = np.amax(np.array([data.y for data in fig.data]))
         plot.add_trace(
@@ -834,7 +835,7 @@ class Report:
         plot_shapes = [
             response.plot_deflected_shape(
                 speed=speed,
-                frequency_units=spd_unit,
+                frequency_units=frequency_units,
                 displacement_units=amplitude_units,
                 rotor_length_units=rotor_length_units,
                 subplot_kwargs=dict(width=800, height=600),

--- a/report/analysis.py
+++ b/report/analysis.py
@@ -56,9 +56,105 @@ class Report:
     Example
     -------
     >>> import ross as rs
+    >>> from ross.materials import steel
     >>> import report as rp
-    >>> rotor = rs.rotor_example()
-    >>> config = rp.Config()
+
+    >>> # Building the rotor model
+    >>> i_d = 0
+    >>> o_d = 0.05
+    >>> n = 6
+    >>> L = [0.25 for _ in range(n)]
+
+    # Shaft
+    >>> shaft_elem = [
+    ...     rs.ShaftElement(
+    ...         l,
+    ...         i_d,
+    ...         o_d,
+    ...         material=steel,
+    ...         shear_effects=True,
+    ...         rotary_inertia=True,
+    ...         gyroscopic=True,
+    ...     )
+    ...     for l in L
+    ... ]
+
+    # Disks
+    >>> disk0 = rs.DiskElement.from_geometry(
+    ...     n=2, material=steel, width=0.07, i_d=0.05, o_d=0.28
+    ... )
+    >>> disk1 = rs.DiskElement.from_geometry(
+    ...     n=4, material=steel, width=0.07, i_d=0.05, o_d=0.28
+    ... )
+
+    # Bearings
+    >>> stfx = [0.4e7, 0.5e7, 0.6e7, 0.7e7]
+    >>> stfy = [0.8e7, 0.9e7, 1.0e7, 1.1e7]
+    >>> freq = [400, 800, 1200, 1600]
+    >>> bearing0 = rs.BearingElement(0, kxx=stfx, kyy=stfy, cxx=2e3, frequency=freq)
+    >>> bearing1 = rs.BearingElement(6, kxx=stfx, kyy=stfy, cxx=2e3, frequency=freq)
+    >>> oper_clerance_brg = [bearing0, bearing1]
+
+    # Rotor
+    >>> rotor = Rotor(shaft_elem, [disk0, disk1], [bearing0, bearing1])
+
+    # coefficients for minimum clearance bearings
+    >>> stfx = [0.7e7, 0.8e7, 0.9e7, 1.0e7]
+    >>> dampx = [2.0e3, 1.9e3, 1.8e3, 1.7e3]
+    >>> freq = [400, 800, 1200, 1600]
+    >>> bearing0 = rs.BearingElement(0, kxx=stfx, cxx=dampx, frequency=freq)
+    >>> bearing1 = rs.BearingElement(6, kxx=stfx, cxx=dampx, frequency=freq)
+    >>> min_clearance_brg = [bearing0, bearing1]
+
+    # coefficients for maximum clearance bearings
+    >>> stfx = [0.4e7, 0.5e7, 0.6e7, 0.7e7]
+    >>> dampx = [2.8e3, 2.7e3, 2.6e3, 2.5e3]
+    >>> freq = [400, 800, 1200, 1600]
+    >>> bearing0 = rs.BearingElement(0, kxx=stfx, cxx=dampx, frequency=freq)
+    >>> bearing1 = rs.BearingElement(6, kxx=stfx, cxx=dampx, frequency=freq)
+    >>> max_clearance_brg = [bearing0, bearing1]
+
+    # Analyses setup
+    >>> config = Config()
+    >>> config.update_config(
+    ...     rotor_properties={
+    ...         "rotor_speeds": {
+    ...             "min_speed": 400,
+    ...             "max_speed": 1000,
+    ...             "oper_speed": 800,
+    ...             "trip_speed": 1200,
+    ...             "unit": "rad/s",
+    ...         }
+    ...     },
+    ...     bearings={
+    ...         "oper_clearance": oper_clerance_brg,
+    ...         "min_clearance": min_clearance_brg,
+    ...         "max_clearance": max_clearance_brg,
+    ...     },
+    ...     run_campbell={"speed_range": np.linspace(0, 1500, 51)},
+    ...     run_unbalance_response={
+    ...         "probes": {
+    ...             "node": [1, 4],
+    ...             "orientation": [np.pi / 2, np.pi / 2],
+    ...             "unit": "rad",
+    ...         },
+    ...         "frequency_range": np.linspace(0, 1500, 201),
+    ...         "plot_deflected_shape": {"speed": [615]},
+    ...     },
+    ...     plot_ucs={"stiffness_range": (5, 8)},
+    ...     stability_level1={
+    ...         "D": [0.35, 0.35],
+    ...         "H": [0.08, 0.08],
+    ...         "rated_power": [10000, 10000],
+    ...         "rho_ratio": [1.11, 1.14],
+    ...         "rho_suction": 30.45,
+    ...         "rho_discharge": 37.65,
+    ...         "length_unit": "m",
+    ...         "power_unit": "hp",
+    ...         "density_unit": "kg/m**3",
+    ...     },
+    ... )
+
     >>> report = rp.Report(rotor=rotor, config=config)
     >>> report.rotor_type
     'between_bearings'
@@ -1284,7 +1380,7 @@ class Report:
         >>> dataframe = report._stability_level_2()
         """
         oper_speed = self.config.rotor_properties.rotor_speeds.oper_speed
-        unit = speed_unit = self.config.rotor_properties.rotor_speeds.unit
+        unit = self.config.rotor_properties.rotor_speeds.unit
         oper_speed = Q_(oper_speed, unit).to("rad/s").m
 
         # Build a list of seals

--- a/report/analysis.py
+++ b/report/analysis.py
@@ -115,7 +115,7 @@ class Report:
     >>> max_clearance_brg = [bearing0, bearing1]
 
     # Analyses setup
-    >>> config = Config()
+    >>> config = rp.Config()
     >>> config.update_config(
     ...     rotor_properties={
     ...         "rotor_speeds": {

--- a/report/config.py
+++ b/report/config.py
@@ -137,8 +137,16 @@ class Config:
     rotordynamics analyses. It's a must to check all the options for a correct
     functioning.
 
+    The Config object works like a dictionary too. It's possible to return an value
+    from a key with the same dict syntax, however, it's not possible to set an item via
+    dict command to avoid introducing new options.
+
+    To update Config options, please use the command .update_config().
+
     The attributes are automatically generated and it's not possible to remove then or
     add new ones.
+
+    PLEASE, READ INSTRUCTIONS CAREFULLY, especially regarding to the units usage.
 
     Attributes
     ----------
@@ -151,17 +159,21 @@ class Config:
 
             min_speed : float
                 The machine minimum operational speed.
+                Units determined by "unit" option.
             max_speed : float
                 The machine  maximum operational speed.
+                Units determined by "unit" option.
             oper_speed : float
                 The machine  nominal operational speed.
+                Units determined by "unit" option.
             trip_speed : float
                 The machine overspeed trip.
+                Units determined by "unit" option.
             speed_factor : float
                 Multiplicative factor of the speed range - according to API 684.
                 Default is 1.50.
             unit : str
-                Unit system to speed values. Options: "rad/s", "rpm".
+                Input unit system to angular speed values. Options: "rad/s", "rpm", ...
                 Default is "rpm".
 
         rotor_id : dict
@@ -192,7 +204,7 @@ class Config:
         Dictionary configurating the mode shape analysis
 
         frequency_units : str
-            Unit for the frequency values.
+            Output unit for the frequency values.
             Default is "rad/s"
 
     run_campbell : dict
@@ -207,7 +219,7 @@ class Config:
             List with the harmonics to be plotted.
             The default is to plot 1x.
         frequency_units : str, optional
-            Unit for the frequency values.
+            Output Unit for the frequency values.
             Default is "rad/s".
 
     plot_ucs : dict
@@ -246,7 +258,7 @@ class Config:
                 0 or π (rad) corresponds to the X orientation and
                 π / 2 or 3 * π / 2 (rad) corresponds to the Y orientation.
             unit : str
-                Unit system for the orientation angle. Can be "rad" or "degree".
+                Input unit system for the orientation angle. Can be "rad" or "degree".
                 Default is "rad".
 
         frequency_range : list, array
@@ -281,16 +293,16 @@ class Config:
             calculate the approximated critical speeds.
             Default is 0.005 (0.5%).
         frequency_units : str, optional
-            Frequency units.
+            Frequency output units.
             Default is "rad/s"
         amplitude_units : str, optional
-            Amplitude units.
+            Amplitude output units.
             Default is "m/N"
         phase_units : str, optional
-            Phase units.
+            Phase output units.
             Default is "rad".
         rotor_length_units : str, optional
-            Units for rotor length.
+            Output units for rotor length.
             Default is "m".
 
         plot_deflected_shape : dict
@@ -299,10 +311,7 @@ class Config:
             speed : list, array
                 List with selected speed to plot the deflected shape.
                 The speed values must be elements from frequency_range option,
-                otherwise it returns an error.
-            speed_units : str, optional
-                Units for selected speed in deflected shape analisys.
-                Default is "rad/s".
+                otherwise it returns an error. (must be in rad/s)
 
     stability_level1 : dict
         Dictionary configurating stability_level_1 parameters.
@@ -355,6 +364,30 @@ class Config:
     >>> configs = Config()
     >>> configs["rotor_properties"]["rotor_id"] # doctest: +ELLIPSIS
     {"type": "compressor", "tag": None}...
+
+    Updating Config
+    >>> configs.update_config(
+    ...     rotor_properties={"rotor_id":{"type": "turbine", "tag": "Model"}},
+    ...     run_campbell={
+    ...         "speed_range": np.linspace(100, 1200, 91),  # must be in rad/s
+    ...         "frequency_units": "rpm",  # defines the output unit for speed_range
+    ...     },
+    ...     run_unbalance_response={
+    ...         "probes": {
+    ...             "node": [22, 39],
+    ...             "orientation": [90, 90],
+    ...             "unit": "degree",  # defines the orientation unit
+    ...         },
+    ...         "frequency_range": np.linspace(100, 1200, 101),  # must be in rad/s
+    ...         "frequency_units": "rpm",  # defines the output unit for frequency_range
+    ...         "plot_deflected_shape": {"speed": [815]},
+    ...     },
+    ... )
+    >>> configs["rotor_properties"]["rotor_id"] # doctest: +ELLIPSIS
+    {"type": "turbine", "tag": "Model"}...
+
+    >>> configs["run_campbell"]["frequency_units"]
+    'rpm'
     """
 
     def __init__(self):
@@ -424,7 +457,6 @@ class Config:
             "rotor_length_units": "m",
             "plot_deflected_shape": {
                 "speed": [],
-                "speed_units": "rad/s",
             },
         })
 

--- a/report/config.py
+++ b/report/config.py
@@ -366,6 +366,7 @@ class Config:
     {"type": "compressor", "tag": None}...
 
     Updating Config
+    >>> import numpy as np
     >>> configs.update_config(
     ...     rotor_properties={"rotor_id":{"type": "turbine", "tag": "Model"}},
     ...     run_campbell={


### PR DESCRIPTION
- Remove `speed_units` option from deflected shape options. It'll use `frequency_units` instead to simplify the units setup.
- `Speed` argument must be passed in SI, just like the `frequency_range` argument from `run_unbalane_response()`. This should avoid errors when code searches for the speed value in the `frequency_range` array. The code still converts it when plotting.
- Improving documentation